### PR TITLE
[chore] Update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "min-review-bot"
 version = "0.2.1"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "cli"
@@ -14,26 +14,24 @@ path = "src/daemon.rs"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.58"
-base64 = "0.13.1"
+base64 = "0.22.1"
 clap = { version = "4.0.25", features = ["derive"] }
 codeowners = "0.1.3"
 datadog-statsd = { git = "https://github.com/dmweis/rust-dogstatsd", rev = "fcb310c3ed55bc83b840b729013d2ba8203530bf" }
 dotenv = "0.15.0"
-env_logger = "0.10.0"
 futures-util = "0.3.28"
-jsonwebtoken = "8.1.1"
+jsonwebtoken = "10.3.0"
 lazy_static = "1.4.0"
-octocrab = "0.17.0"
+octocrab = "0.49.5"
 opentelemetry = { version = "0.20.0", features = ["trace", "metrics", "logs", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.13.0", features = ["trace", "metrics", "logs"] }
-opentelemetry-stdout = { version = "0.1.0", features = ["trace", "metrics", "logs"] }
 opentelemetry_api = { version = "0.20.0", features = ["trace", "metrics", "logs"] }
 serde = "1.0"
-sqlx = { version = "0.6", features = [ "runtime-tokio-rustls", "sqlite" ] }
-thiserror = "1"
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite"] }
+thiserror = "2.0"
 tokio = { version = "1.21.2", features = ["full"] }
 toml = "0.5.9"
-tracing = "0.1.37"
+tracing = "0.1.44"
 tracing-opentelemetry = { version = "0.20.0", features = ["metrics"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json", "registry"] }
-unidiff = "0.3.3"
+unidiff = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/cli.rs"
 name = "daemon"
 path = "src/daemon.rs"
 
+[lints.rust]
+warnings = "deny"
+
 [dependencies]
 anyhow = "1"
 async-trait = "0.1.58"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH=
-FROM ${ARCH}lukemathwalker/cargo-chef:latest-rust-1-buster AS chef
-WORKDIR app
+FROM ${ARCH}lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
+WORKDIR /app
 
 FROM chef AS planner
 
@@ -24,11 +24,11 @@ COPY min.env .env
 RUN sqlite3 test.db < sql/create.sql
 RUN cargo build --release --bin daemon
 
-FROM ${ARCH}debian:buster-slim
+FROM ${ARCH}debian:bookworm-slim
 COPY --from=builder /app/target/release/daemon /usr/local/bin/min_review_daemon
 
 RUN apt-get update \
-    && apt-get install -y libssl1.1 sqlite3 ca-certificates \
+    && apt-get install -y libssl3 sqlite3 ca-certificates \
     && apt-get autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use min_review_bot::{
     conditional::OwnersConditional,
     github::{GithubSource, Repo, RepoConnector},
 };
-use octocrab::{models::AppId, Octocrab};
+use octocrab::{Octocrab, models::AppId};
 use std::{env, path::PathBuf};
 
 #[derive(Parser, Debug)] // requires `derive` feature
@@ -30,10 +30,14 @@ async fn main() -> anyhow::Result<()> {
     let pem_data = tokio::fs::read(PathBuf::from(pem_path)).await?;
     let repo = Repo::from_path(&args.repo)?;
 
-    octocrab::initialise(Octocrab::builder().app(
-        AppId(env::var("GITHUB_APP_ID")?.parse()?),
-        EncodingKey::from_rsa_pem(&pem_data)?,
-    ))?;
+    octocrab::initialise(
+        Octocrab::builder()
+            .app(
+                AppId(env::var("GITHUB_APP_ID")?.parse()?),
+                EncodingKey::from_rsa_pem(&pem_data)?,
+            )
+            .build()?,
+    );
 
     let repo_connector = RepoConnector::new(GithubSource::new_authorized(repo.user()).await?, repo);
     let changed_files = repo_connector.get_pr_changed_files(args.pr_num).await?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -38,13 +38,13 @@ async fn main() -> anyhow::Result<()> {
     setup_tracing(&config)?;
     info!(config = ?config, "starting node");
 
-    if let Some(datadog_socket) = config.datadog_socket.as_ref() {
-        if let Err(e) = MetricsReporter::initialise(datadog_socket) {
-            warn!(
-                error = ?e,
-                "There was an error initialising connection to datadog; continuing"
-            );
-        }
+    if let Some(datadog_socket) = config.datadog_socket.as_ref()
+        && let Err(e) = MetricsReporter::initialise(datadog_socket)
+    {
+        warn!(
+            error = ?e,
+            "There was an error initialising connection to datadog; continuing"
+        );
     }
 
     let pem_data = fetch_pem_data(&config).await?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,8 +10,8 @@ use min_review_bot::{
     metrics::MetricsReporter,
 };
 use octocrab::{
-    models::{pulls::PullRequest, AppId},
     Octocrab,
+    models::{AppId, pulls::PullRequest},
 };
 use opentelemetry::sdk::Resource;
 use opentelemetry_api::KeyValue;
@@ -52,10 +52,14 @@ async fn main() -> anyhow::Result<()> {
 
     let db = Cache::new(&config).await?;
 
-    octocrab::initialise(Octocrab::builder().app(
-        AppId(config.github.app_id),
-        EncodingKey::from_rsa_pem(&pem_data)?,
-    ))?;
+    octocrab::initialise(
+        Octocrab::builder()
+            .app(
+                AppId(config.github.app_id),
+                EncodingKey::from_rsa_pem(&pem_data)?,
+            )
+            .build()?,
+    );
     let repo_connector = RepoConnector::new(GithubSource::new_authorized(repo.user()).await?, repo);
 
     let mut next_awake = Instant::now() + config.sleep_period;

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,9 +1,10 @@
-/// This file provides a basic interface into Github that can be easily replaced and mocked out for
-/// use when testing other parts of the codebase.
+//! This file provides a basic interface into GitHub that can be easily replaced
+//! and mocked out for use when testing other parts of the codebase.
+use base64::{Engine as _, engine::general_purpose::STANDARD as base64_engine};
 use octocrab::{
-    models::{issues::Comment, pulls::PullRequest, CommentId},
-    params::State as PrState,
     Octocrab,
+    models::{CommentId, issues::Comment, pulls::PullRequest},
+    params::State as PrState,
 };
 use std::collections::BTreeSet;
 use tracing::instrument;
@@ -139,7 +140,7 @@ impl GithubSource {
 
         let installation_id =
             installation_id.ok_or_else(|| Error::NoInstallationId(user.into()))?;
-        let octo_instance = octocrab::instance().installation(installation_id);
+        let octo_instance = octocrab::instance().installation(installation_id)?;
 
         Ok(GithubSource { octo_instance })
     }
@@ -221,7 +222,7 @@ impl RepoSource for GithubSource {
             .ok_or(Error::EmptyContents)?
             .replace('\n', "");
 
-        Ok(String::from_utf8(base64::decode(raw_contents)?)?)
+        Ok(String::from_utf8(base64_engine.decode(raw_contents)?)?)
     }
 
     #[instrument(level = "debug", err)]


### PR DESCRIPTION
# Updates
- Dockerfile:
  - `buster -> bookworm` buster is at EOL.
  - `libssl1.1 -> libssl3` newer OS does not support 1.1
- Cargo:
  - rust edition `2021 -> 2024`.
  - several safe updates on dependencies. Honourable mention `octocrab = "0.49.5"` which exposes much clearer error messages when contacting GitHub.
  - removed unused dependencies: `env_logger`, `opentelemetry-stdout`.
- Minimal code changes to satisfy newer dependencies.